### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "can-stache-route-helpers",
   "version": "1.0.0",
   "description": "stache helpers for can-route",
-  "homepage": "http://canjs.com",
+  "homepage": "https://canjs.com/doc/can-stache-route-helpers.html",
   "repository": {
     "type": "git",
-    "url": "git://github.com/donejs/can-stache-route-helpers.git"
+    "url": "git://github.com/canjs/can-stache-route-helpers.git"
   },
   "author": {
     "name": "DoneJS Core",
@@ -20,8 +20,7 @@
     "jshint": "jshint ./*.js --config",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish",
-    "develop": "done-serve --static --develop --port 8080"
+    "release:major": "npm version major && npm publish"
   },
   "main": "can-stache-route-helpers",
   "keywords": [
@@ -43,12 +42,13 @@
     "can-stache": "^4.0.0"
   },
   "devDependencies": {
-    "can-map": "^4.0.0-pre.0",
+    "can-map": "^4.1.1",
+    "can-route-mock": "^1.0.0",
     "jshint": "^2.9.1",
     "steal": "^1.3.1",
     "steal-qunit": "^1.0.1",
     "steal-tools": "^1.2.0",
-    "testee": "^0.3.0"
+    "testee": "^0.8.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
can-route-map had to be added under devDependencies and a file in can-map was still using can-util.

Also:

- Remove script that used uninstalled dependency
- Update devDependencies & homepage