### PR TITLE
15 documentation updates

### DIFF
--- a/docs/can-stache-route-helpers.md
+++ b/docs/can-stache-route-helpers.md
@@ -10,31 +10,57 @@
   The can-stache-route-helpers module doesn't export anything; It mixes in the following [can-stache] helpers that use [can-route]:
 
   - [can-stache-route-helpers.routeUrl]
-    Use the `routeUrl` helper like:
+    The example below shows how to produce a hyperlink reference on an anchor element using the `routeUrl` helper.
 
     ```html
-    <a href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>
-    ```
+    <mock-url></mock-url>
+    <cooking-example></cooking-example>
+    <script type="module">
+    import {Component} from "can";
+    import "//unpkg.com/mock-url@^5";
 
-    This produces (with no pretty routing rules):
-
-    ```html
-    <a href='#!&page=recipe&id=5'>{{recipe.name}}</a>
+    Component.extend({
+      tag: "cooking-example",
+      view: `<a href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>`,
+      ViewModel: {
+        recipe: {
+          default() {
+            return {name: "apple pie"};
+          }
+        }
+      }
+    });
+    </script>
     ```
+    @codepen
 
   - [can-stache-route-helpers.routeCurrent]
-    Use the `routeCurrent` helper like:
+    The next example shows how to use `routeCurrent` helper. If the url matches the parameters in `routeCurrent` it will add the `'active'` class to the list item, changing the background color:
 
     ```html
-    <li {{# routeCurrent(page="recipe" id=5) }}class='active'{{/ routeCurrent }}>
-      <a href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>
-    </li>
+    <mock-url></mock-url>
+    <cooking-example></cooking-example>
+    <style>
+      .active {
+        background-color: darkred;
+      }
+    </style>
+    <script type="module">
+    import {Component} from "can";
+    import "//unpkg.com/mock-url@^5";
+    Component.extend({
+      tag: "cooking-example",
+      view: `<li {{# routeCurrent(page="recipe" id=5) }}class='active'{{/ routeCurrent }}>
+          <a href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>
+        </li>`,
+      ViewModel: {
+        recipe: {
+          default() {
+            return {name: "apple pie"};
+          }
+        }
+      }
+    });
+    </script>
     ```
-
-    With default routes and a url like `#!&page=recipe&id=5`, this produces:
-
-    ```html
-    <li class='active'>
-      <a href='#!&page=recipe&id=5'>{{recipe.name}}</a>
-    </li>
-    ```
+    @codepen

--- a/docs/can-stache-route-helpers.md
+++ b/docs/can-stache-route-helpers.md
@@ -7,7 +7,7 @@
 
 @type {undefined}
 
-  The can-stache-route-helpers module doesn't export anything; It mixes in the following [can-stache] helpers that use [can-route]:
+  The can-stache-route-helpers module doesn't export anything. It mixes in the following [can-stache] helpers that use [can-route]:
 
   - [can-stache-route-helpers.routeUrl]
     The example below shows how to produce a hyperlink reference on an anchor element using the `routeUrl` helper.
@@ -17,7 +17,7 @@
     <cooking-example></cooking-example>
     <script type="module">
     import {Component} from "can";
-    import "//unpkg.com/mock-url@^5";
+    import "//unpkg.com/mock-url@5";
 
     Component.extend({
       tag: "cooking-example",
@@ -42,16 +42,18 @@
     <cooking-example></cooking-example>
     <style>
       .active {
-        background-color: darkred;
+        color: black;
+        text-decoration: none;
       }
     </style>
     <script type="module">
     import {Component} from "can";
-    import "//unpkg.com/mock-url@^5";
+    import "//unpkg.com/mock-url@5";
     Component.extend({
       tag: "cooking-example",
-      view: `<li {{# routeCurrent(page="recipe" id=5) }}class='active'{{/ routeCurrent }}>
-          <a href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>
+      view: `<li>
+          <a {{# routeCurrent(page="recipe" id=5) }}class='active'{{/ routeCurrent }}
+          href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>
         </li>`,
       ViewModel: {
         recipe: {

--- a/docs/routeCurrent.md
+++ b/docs/routeCurrent.md
@@ -1,30 +1,36 @@
-@function can-stache-route-helpers.routeCurrent {{# routeCurrent(hash) }}
+@function can-stache-route-helpers.routeCurrent routeCurrent(hash)
 @parent can-stache-route-helpers
 
 @description Returns if the hash values match the [can-route]’s current properties.
 
 @signature `routeCurrent( hashes... [,subsetMatch] )`
 
-  Calls [can-route.isCurrent route.isCurrent] with `hashes` and returns the result. The next example adds the `'active'` class on the anchor if `page` is equal to `todos`.
+  Calls [can-route.isCurrent route.isCurrent] with `hashes` and returns the result. The following example adds the `'active'` class on the anchor if [can-route.data `route.data.page`] is equal to `"recipes"` and [can-route.data `route.data.id`] is equal to `5`.
 
   ```html
   <mock-url></mock-url>
   <cooking-example></cooking-example>
   <style>
-  .active { background-color: darkred; }
+  .active {
+    color: black;
+    text-decoration: none;
+  }
   </style>
   <script type="module">
   import {Component} from "can";
-  import "//unpkg.com/mock-url@^5";
+  import "//unpkg.com/mock-url@5";
+
   Component.extend({
     tag: "cooking-example",
-    view: `<li {{# routeCurrent(page="recipe" id=5) }}class='active'{{/ routeCurrent }}>
-        <a href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>
-      </li>`,
+    view: `
+      <a {{# routeCurrent(page="recipe", true) }}class='active'{{/ routeCurrent }}
+        href='{{ routeUrl(page="recipe" id=5) }}'
+      >{{recipe.name}}</a>
+    `,
     ViewModel: {
       recipe: {
         default() {
-          return {name: "apple pie"};
+          return [{name: "apple pie"}];
         }
       }
     }
@@ -43,64 +49,54 @@
 
   `routeCurrent` can also be used with other [can-stache.Helpers].
 
-  @param {can-stache/expressions/hash} hashes A hash expression like `page='edit' recipeId=id`.
+  @param {can-stache/expressions/hash} hashes A hash expression like `page='recipe' recipeId=id`.
 
   @param {Boolean} [subsetMatch] If an optional `true` is passed, `routeCurrent` will
   return `true` if every value in `hashes` matches the current route data, even if
   the route data has additional properties that are not matched.
+   
+   In the following example notice that the active class will apply when clicking on `pie`, but not `cake`.
+   ```html
+   <mock-url></mock-url>
+   <cooking-example></cooking-example>
+   <style>
+   .active {
+     color: black;
+     text-decoration: none;
+   }
+   </style>
+   <script type="module">
+   import {Component} from "can";
+   import "//unpkg.com/mock-url@5";
+
+   Component.extend({
+     tag: "cooking-example",
+     view: `
+       <a {{# routeCurrent(id="pie" true) }}class='active'{{/ routeCurrent }}
+         href='{{ routeUrl(page="recipe" id="pie" }}'
+       >{{pie.name}}</a>
+       <a {{# routeCurrent(id="cake") }}class='active'{{/ routeCurrent }}
+         href='{{ routeUrl(page="recipe" id="cake" }}'
+       >{{cake.name}}</a>
+     `,
+     ViewModel: {
+       pie: {
+         default() {
+           return {name: "apple pie"}
+         }
+       },
+       cake:{
+         default() {
+           return {name: "chocolate cake"}
+         }
+       }
+     }
+   });
+   </script>
+   ```
+   @codepen
 
   @return {Boolean} Returns the result of calling [can-route.isCurrent route.isCurrent].
-
-@signature `{{# routeCurrent([subsetMatch,] hashes...) }}FN{{else}}INVERSE{{/ routeCurrent }}`
-
-  Renders `FN` if the `hashes` passed to [can-route.isCurrent route.isCurrent] returns `true`.
-  Renders the `INVERSE` if [can-route.isCurrent route.isCurrent] returns `false`.
-
-  ```html
-  <mock-url></mock-url>
-  <todo-item></todo-item>
-  <style>
-  .active{ background-color: red; }
-  .inactive{ background-color: dimgray; }
-  </style>
-  <script type="module">
-  import {Component, route} from "can";
-  import "//unpkg.com/mock-url@^5";
-
-  Component.extend({
-    tag: "todo-item",
-    view: `<a href='{{ routeUrl(page='todos' id=3) }}'
-      class='{{# routeCurrent(true, page='todos') }}
-        active
-      {{else}}
-        inactive
-      {{/ routeCurrent }}'>
-        {{todo.name}}
-      </a>`,
-    ViewModel: {
-      todo: {
-        default() {
-          return {name: "eat apple pie"};
-        }
-      }
-    }
-  });
-  </script>
-  ```
-  @codepen
-
-  @param {Boolean} [subsetMatch] If an optional `true` is passed, `routeCurrent` will
-  return `true` if every value in `hashes` matches the current route data, even if
-  the route data has additional properties that are not matched.
-
-  @param {can-stache/expressions/hash} hashes A hash expression like `page='edit' recipeId=id`.
-
-  @param {can-stache.sectionRenderer} FN A subsection that will be rendered if the current route matches `hashes`.
-
-  @param {can-stache.sectionRenderer} [INVERSE] An optional subsection that will be rendered
-  if the current route does not match `hashes`.
-
-  @return {String} The result of `SUBEXPRESSION` or `{{else}}` expression.
 
 @body
 
@@ -109,4 +105,38 @@
 The following demo uses `routeCurrent` and [can-stache-route-helpers.routeUrl] to
 create links that update [can-route]’s `page` attribute:
 
-@demo demos/can-stache/route-url.html
+```html
+<my-nav></my-nav>
+<script type="module">
+import {Component, route} from "can";
+
+Component.extend({
+  tag: "my-nav",
+  view: `
+    <a {{^ routeCurrent(page='home') }}
+      href="{{ routeUrl(page='home') }}"
+      {{/ routeCurrent }}
+    >home</a>
+    <a {{^ routeCurrent(page='restaurants') }}
+      href="{{ routeUrl(page='restaurants') }}"
+      {{/ routeCurrent }}
+    >restaurants</a>
+    {{# eq(routeData.page, 'home') }}
+      <h1>Home page</h1>
+    {{ else }}
+      <h1>Restaurants page</h1>
+    {{/ eq }}
+  `,
+  ViewModel: {
+    routeData: {
+      default() {
+        route.register("{page}", {page: "home"});
+        route.start();
+        return route.data;
+      }
+    }
+  }
+});
+</script>
+```
+@codepen

--- a/docs/routeCurrent.md
+++ b/docs/routeCurrent.md
@@ -74,23 +74,11 @@
      view: `
        <a {{# routeCurrent(id="pie" true) }}class='active'{{/ routeCurrent }}
          href='{{ routeUrl(page="recipe" id="pie" }}'
-       >{{pie.name}}</a>
+       >apple pie</a>
        <a {{# routeCurrent(id="cake") }}class='active'{{/ routeCurrent }}
          href='{{ routeUrl(page="recipe" id="cake" }}'
-       >{{cake.name}}</a>
+       >chocolate cake</a>
      `,
-     ViewModel: {
-       pie: {
-         default() {
-           return {name: "apple pie"}
-         }
-       },
-       cake:{
-         default() {
-           return {name: "chocolate cake"}
-         }
-       }
-     }
    });
    </script>
    ```

--- a/docs/routeCurrent.md
+++ b/docs/routeCurrent.md
@@ -1,22 +1,47 @@
 @function can-stache-route-helpers.routeCurrent {{# routeCurrent(hash) }}
 @parent can-stache-route-helpers
 
-Returns if the hash values match the [can-route]’s current properties.
+@description Returns if the hash values match the [can-route]’s current properties.
 
 @signature `routeCurrent( hashes... [,subsetMatch] )`
 
-  Calls [can-route.isCurrent route.isCurrent] with `hashes` and returns the result. This
-  can be used in conjunction with other helpers:
+  Calls [can-route.isCurrent route.isCurrent] with `hashes` and returns the result. The next example adds the `'active'` class on the anchor if `page` is equal to `todos`.
 
-```html
-{{linkTo("Todos", routeCurrent(page='todos' id=todo.id))}}
-```
+  ```html
+  <mock-url></mock-url>
+  <cooking-example></cooking-example>
+  <style>
+  .active { background-color: darkred; }
+  </style>
+  <script type="module">
+  import {Component} from "can";
+  import "//unpkg.com/mock-url@^5";
+  Component.extend({
+    tag: "cooking-example",
+    view: `<li {{# routeCurrent(page="recipe" id=5) }}class='active'{{/ routeCurrent }}>
+        <a href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>
+      </li>`,
+    ViewModel: {
+      recipe: {
+        default() {
+          return {name: "apple pie"};
+        }
+      }
+    }
+  });
+  </script>
+  ```
+  @codepen
 
-Or on its own:
+  With default routes and a url like `#!&page=recipe&id=5`, this produces:
 
-```html
-<a class="{{# routeCurrent(page='todos', true) }}active{{/ routeCurrent }}">Todos</a>
-```
+  ```html
+  <li class='active'>
+    <a href='#!&page=recipe&id=5'>{{recipe.name}}</a>
+  </li>
+  ```
+
+  `routeCurrent` can also be used with other [can-stache.Helpers].
 
   @param {can-stache/expressions/hash} hashes A hash expression like `page='edit' recipeId=id`.
 
@@ -28,20 +53,47 @@ Or on its own:
 
 @signature `{{# routeCurrent([subsetMatch,] hashes...) }}FN{{else}}INVERSE{{/ routeCurrent }}`
 
-Renders `FN` if the `hashes` passed to [can-route.isCurrent route.isCurrent] returns `true`.
-Renders the `INVERSE` if [can-route.isCurrent route.isCurrent] returns `false`.
+  Renders `FN` if the `hashes` passed to [can-route.isCurrent route.isCurrent] returns `true`.
+  Renders the `INVERSE` if [can-route.isCurrent route.isCurrent] returns `false`.
 
-```html
-<a class="{{# routeCurrent(true, page='todos') }}active{{/ routeCurrent }}">Todos</a>
-```
+  ```html
+  <mock-url></mock-url>
+  <todo-item></todo-item>
+  <style>
+  .active{ background-color: red; }
+  .inactive{ background-color: dimgray; }
+  </style>
+  <script type="module">
+  import {Component, route} from "can";
+  import "//unpkg.com/mock-url@^5";
+
+  Component.extend({
+    tag: "todo-item",
+    view: `<a href='{{ routeUrl(page='todos' id=3) }}'
+      class='{{# routeCurrent(true, page='todos') }}
+        active
+      {{else}}
+        inactive
+      {{/ routeCurrent }}'>
+        {{todo.name}}
+      </a>`,
+    ViewModel: {
+      todo: {
+        default() {
+          return {name: "eat apple pie"};
+        }
+      }
+    }
+  });
+  </script>
+  ```
+  @codepen
 
   @param {Boolean} [subsetMatch] If an optional `true` is passed, `routeCurrent` will
   return `true` if every value in `hashes` matches the current route data, even if
   the route data has additional properties that are not matched.
 
   @param {can-stache/expressions/hash} hashes A hash expression like `page='edit' recipeId=id`.
-
-
 
   @param {can-stache.sectionRenderer} FN A subsection that will be rendered if the current route matches `hashes`.
 
@@ -50,28 +102,9 @@ Renders the `INVERSE` if [can-route.isCurrent route.isCurrent] returns `false`.
 
   @return {String} The result of `SUBEXPRESSION` or `{{else}}` expression.
 
-
-
 @body
 
 ## Use
-
-Use the `routeCurrent` helper like:
-
-```html
-<li {{# routeCurrent(page="recipe" id=5) }}class='active'{{/ routeCurrent }}>
-  <a href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>
-</li>
-```
-
-With default routes and a url like `#!&page=recipe&id=5`, this produces:
-
-```html
-<li class='active'>
-  <a href='#!&page=recipe&id=5'>{{recipe.name}}</a>
-</li>
-```
-
 
 The following demo uses `routeCurrent` and [can-stache-route-helpers.routeUrl] to
 create links that update [can-route]’s `page` attribute:

--- a/docs/routeCurrent.md
+++ b/docs/routeCurrent.md
@@ -47,8 +47,6 @@
   </li>
   ```
 
-  `routeCurrent` can also be used with other [can-stache.Helpers].
-
   @param {can-stache/expressions/hash} hashes A hash expression like `page='recipe' recipeId=id`.
 
   @param {Boolean} [subsetMatch] If an optional `true` is passed, `routeCurrent` will

--- a/docs/routeUrl.md
+++ b/docs/routeUrl.md
@@ -1,4 +1,4 @@
-@function can-stache-route-helpers.routeUrl {{ routeUrl(hashes) }}
+@function can-stache-route-helpers.routeUrl routeUrl(hashes)
 @parent can-stache-route-helpers
 
 @description Returns a url using [can-route.url route.url].
@@ -15,7 +15,7 @@
   <cooking-example></cooking-example>
   <script type="module">
   import {Component} from "can";
-  import "//unpkg.com/mock-url@^5";
+  import "//unpkg.com/mock-url@5";
 
   Component.extend({
     tag: "cooking-example",
@@ -38,46 +38,41 @@
   <a href='#!&page=recipe&id=5'>{{recipe.name}}</a>
   ```
 
-  @param {can-stache/expressions/hash} [hashes...] A hash expression like `page='edit' recipeId=id`.
+  @param {can-stache/expressions/hash|undefined} [hashes...] A hash expression like `page='edit' recipeId=id`. Passing `undefined` has the effect of writing out the current url.
 
   @param {Boolean} [merge] Pass `true` to create a url that merges `hashes` into the
-  current [can-route] properties.  
+  current [can-route] properties.
 
-  @return {String} Returns the result of calling `route.url`.
-
-@signature `{{ routeUrl([merge,] hashes...) }}`
-
-  Passes the hashes to `route.url` and returns the result.
-  Using call expressions/parenthesis lets you pass the `merge` option to `route`.  This
-  lets you write a url that only changes specified properties. The example below clicking __recipes__ will add a `page` hash, and clicking on the recipe name will add the `id`:
-
-  ```html
-  <mock-url></mock-url>
-  <cooking-example></cooking-example>
-  <script type="module">
-  import {Component} from "can";
-  import "//unpkg.com/mock-url@^5";
-
-  Component.extend({
-    tag: "cooking-example",
-    view: `<a href='{{ routeUrl(true, page="recipes") }}'>recipes</a>
-      <a href='{{ routeUrl(true, id=5) }}'>{{recipe.name}}</a>`,
-    ViewModel: {
-      recipe: {
-        default() {
-          return {name: "apple pie"};
-        }
-      }
-    }
-  });
-  </script>
-  ```
-  @codepen
-
-  @param {Boolean} [merge] Pass `true` to create a url that merges `hashes` into the
-  current [can-route] properties.  
-
-  @param {can-stache/expressions/hash} [hashes...] A hash expression like `page='edit' recipeId=id`.
+   In the following example notice that `#!&page=recipe` is in hash before clicking the link. After the link is `#!&page=recipe&id=5`:
+ 
+   ```html
+   <mock-url></mock-url>
+   <cooking-example></cooking-example>
+   <script type="module">
+   import {Component, route} from "can";
+   import "//unpkg.com/mock-url@5";
+ 
+     Component.extend({
+     tag: "cooking-example",
+     view: `<a href='{{ routeUrl(id=5) }}'>{{recipe.name}}</a>`,
+     ViewModel: {
+       routeData: {
+         default() {
+           route.data.page="recipe";
+           route.start();
+           return route.data;
+         }
+       },
+       recipe: {
+         default() {
+           return {name: "apple pie"};
+         }
+       }
+     }
+   });
+   </script>
+   ```
+   @codepen;
 
   @return {String} Returns the result of calling `route.url`.
 
@@ -85,10 +80,44 @@
 
 ## Use
 
-The following demo uses `routeUrl` and [can-stache-route-helpers.routeCurrent] to
+The following example uses `routeUrl` and [can-stache-route-helpers.routeCurrent] to
 create links that update [can-route]’s `page` attribute:
 
-@demo demos/can-stache/route-url.html
+```html
+<my-nav></my-nav>
+<script type="module">
+import {Component, route} from "can";
+
+Component.extend({
+  tag: "my-nav",
+  view: `
+    <a {{^ routeCurrent(page='home') }}
+      href="{{ routeUrl(page='home') }}"
+      {{/ routeCurrent }}
+    >home</a>
+    <a {{^ routeCurrent(page='restaurants') }}
+      href="{{ routeUrl(page='restaurants') }}"
+      {{/ routeCurrent }}
+    >restaurants</a>
+    {{# eq(routeData.page, 'home') }}
+      <h1>Home page</h1>
+    {{ else }}
+      <h1>Restaurants page</h1>
+    {{/ eq }}
+  `,
+  ViewModel: {
+    routeData: {
+      default() {
+        route.register("{page}", {page: "home"});
+        route.start();
+        return route.data;
+      }
+    }
+  }
+});
+</script>
+```
+@codepen
 
 It also writes out the current url like:
 

--- a/docs/routeUrl.md
+++ b/docs/routeUrl.md
@@ -1,65 +1,82 @@
 @function can-stache-route-helpers.routeUrl {{ routeUrl(hashes) }}
 @parent can-stache-route-helpers
 
-Returns a url using [can-route.url route.url].
+@description Returns a url using [can-route.url route.url].
 
 @signature `routeUrl( hashes... [,merge] )`
 
-Calls [can-route.url route.url] with  `hashes` as its `data` argument and an
-optional `merge`.
+  Calls [can-route.url route.url] with  `hashes` as its `data` argument and an
+  optional `merge`. `routeUrl` can be used in conjunction with other helpers.
 
-This can be used on its own to create `<a>` `href`s like:
+  This can be used on its own to create `<a>` `href`s like:
 
-```html
-<a href="{{ routeUrl(page='todos' id=todo.id) }}">details</a>
-```
+  ```html
+  <mock-url></mock-url>
+  <cooking-example></cooking-example>
+  <script type="module">
+  import {Component} from "can";
+  import "//unpkg.com/mock-url@^5";
 
-Or in conjunction with other helpers:
+  Component.extend({
+    tag: "cooking-example",
+    view: `<a href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>`,
+    ViewModel: {
+      recipe: {
+        default() {
+          return {name: "apple pie"};
+        }
+      }
+    }
+  });
+  </script>
+  ```
+  @codepen
 
-```html
-{{ makeLink( "details", routeUrl(page='todos', true) ) }}
-```
+  This produces (with no pretty routing rules):
+
+  ```html
+  <a href='#!&page=recipe&id=5'>{{recipe.name}}</a>
+  ```
 
 @signature `{{ routeUrl([merge,] hashes...) }}`
 
-Passes the hashes to `route.url` and returns the result.
+  Passes the hashes to `route.url` and returns the result.
+  Using call expressions/parenthesis lets you pass the `merge` option to `route`.  This
+  lets you write a url that only changes specified properties. The example below clicking __recipes__ will add a `page` hash, and clicking on the recipe name will add the `id`:
 
-```html
-<a href="{{ routeUrl(page='todos' id=todo.id) }}">details</a>
-```
+  ```html
+  <mock-url></mock-url>
+  <cooking-example></cooking-example>
+  <script type="module">
+  import {Component} from "can";
+  import "//unpkg.com/mock-url@^5";
 
-@param {Boolean} [merge] Pass `true` to create a url that merges `hashes` into the
-current [can-route] properties.  
+  Component.extend({
+    tag: "cooking-example",
+    view: `<a href='{{ routeUrl(true, page="recipes") }}'>recipes</a>
+      <a href='{{ routeUrl(true, id=5) }}'>{{recipe.name}}</a>`,
+    ViewModel: {
+      recipe: {
+        default() {
+          return {name: "apple pie"};
+        }
+      }
+    }
+  });
+  </script>
+  ```
+  @codepen
 
-@param {can-stache/expressions/hash} [hashes...] A hash expression like `page='edit' recipeId=id`.
+  @param {Boolean} [merge] Pass `true` to create a url that merges `hashes` into the
+  current [can-route] properties.  
 
-@return {String} Returns the result of calling `route.url`.
+  @param {can-stache/expressions/hash} [hashes...] A hash expression like `page='edit' recipeId=id`.
+
+  @return {String} Returns the result of calling `route.url`.
 
 @body
 
 ## Use
-
-Use the `routeUrl` helper like:
-
-```html
-<a href='{{ routeUrl(page="recipe" id=5) }}'>{{recipe.name}}</a>
-```
-
-This produces (with no pretty routing rules):
-
-```html
-<a href='#!&page=recipe&id=5'>{{recipe.name}}</a>
-```
-
-Using call expressions/parenthesis lets you pass the `merge` option to `route`.  This
-lets you write a url that only changes specified properties:
-
-```html
-<a href='{{ routeUrl(id=5, true) }}'>{{recipe.name}}</a>
-```
-
-
-
 
 The following demo uses `routeUrl` and [can-stache-route-helpers.routeCurrent] to
 create links that update [can-route]’s `page` attribute:

--- a/docs/routeUrl.md
+++ b/docs/routeUrl.md
@@ -38,6 +38,13 @@
   <a href='#!&page=recipe&id=5'>{{recipe.name}}</a>
   ```
 
+  @param {can-stache/expressions/hash} [hashes...] A hash expression like `page='edit' recipeId=id`.
+
+  @param {Boolean} [merge] Pass `true` to create a url that merges `hashes` into the
+  current [can-route] properties.  
+
+  @return {String} Returns the result of calling `route.url`.
+
 @signature `{{ routeUrl([merge,] hashes...) }}`
 
   Passes the hashes to `route.url` and returns the result.

--- a/docs/routeUrl.md
+++ b/docs/routeUrl.md
@@ -52,24 +52,12 @@
    import {Component, route} from "can";
    import "//unpkg.com/mock-url@5";
  
-     Component.extend({
+   Component.extend({
      tag: "cooking-example",
-     view: `<a href='{{ routeUrl(id=5) }}'>{{recipe.name}}</a>`,
-     ViewModel: {
-       routeData: {
-         default() {
-           route.data.page="recipe";
-           route.start();
-           return route.data;
-         }
-       },
-       recipe: {
-         default() {
-           return {name: "apple pie"};
-         }
-       }
-     }
+     view: `<a href='{{ routeUrl(id=5, true) }}'>Apple Pie</a>`,
    });
+   route.data.set("page", "recipe");
+   route.start();
    </script>
    ```
    @codepen;


### PR DESCRIPTION
fixes most problems listed in #15  

## [can-route-stache-handlers.html](https://canjs.com/doc/can-stache-route-helpers.html)
- [x] codepen
- [x] reformatted to prevent `@codepen` from bugging the next lines into a `code-toolbar` that breaks away from the list item.

## [can-stache-route-helpers.routeCurrent.html](https://canjs.com/doc/can-stache-route-helpers.routeCurrent.html)
- [x] codepen
  - [x] Questioning the relevance of having codepen for stache helpers. Instead made comment.
- [x] `@description`
- [x] indentation
- [x] moved use example to signature

## [can-stache-route-helpers.routeUrl.html](https://canjs.com/doc/can-stache-route-helpers.routeUrl.html)
- [x] codepen
 - [x] Questioning the relevance of having codepen for stache helpers. Instead made comment.
- [x] `@description`
- [x] indentation
- [x] moved use example to signature
- [x] added @params to first signature
